### PR TITLE
Release/0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "release-automation",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -226,12 +226,12 @@
       "dev": true
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
       "requires": {
-        "follow-redirects": "^1.3.0",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
       }
     },
     "babel-code-frame": {
@@ -404,11 +404,11 @@
       }
     },
     "debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.0.0"
       }
     },
     "diff": {
@@ -495,11 +495,11 @@
       }
     },
     "follow-redirects": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
-      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
-        "debug": "^3.2.6"
+        "debug": "=3.1.0"
       }
     },
     "fs.realpath": {
@@ -657,9 +657,9 @@
       "dev": true
     },
     "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
     },
     "is-ci": {
       "version": "2.0.0",
@@ -705,9 +705,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -772,9 +772,9 @@
       "dev": true
     },
     "ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multimatch": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typescript": "^3.3.3"
   },
   "dependencies": {
-    "axios": "^0.18.0",
+    "axios": "^0.19.0",
     "chalk": "^2.4.2",
     "inquirer": "^6.2.2",
     "semver": "^5.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "release-automation",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "An opinionated CLI for release automation",
   "main": "bin/index.js",
   "bin": {

--- a/src/utilities/git.ts
+++ b/src/utilities/git.ts
@@ -120,9 +120,7 @@ export async function createBranch(
 /**
  * @param branchName The name of the branch you want to merge into the current branch
  */
-export async function mergeBranch(
-  branchName: string,
-): Promise<IResponseString> {
+export async function mergeBranch(branchName: string): Promise<IResponseString> {
   const cmd = `git merge ${ORIGIN}${branchName}`;
 
   const promise: Promise<IResponseString> = new Promise(res => {
@@ -142,9 +140,7 @@ export async function mergeBranch(
  * @param branches The list of branches you want to merge into the current branch
  * @returns A list of error messages
  */
-export async function mergeBranches(
-  branches: string[],
-): Promise<IResponseStringList> {
+export async function mergeBranches(branches: string[]): Promise<IResponseStringList> {
   const succesfulMerges: string[] = [];
 
   for (const branch of branches) {
@@ -186,8 +182,8 @@ export async function push(
   return promise;
 }
 
-export async function pushTags(): Promise<IResponseString> {
-  const cmd = 'git push origin --tags';
+export async function pushTags(tagVersion: string): Promise<IResponseString> {
+  const cmd = `git push origin ${tagVersion}`;
 
   const promise: Promise<IResponseString> = new Promise(res => {
     exec(cmd, (err, value) => {
@@ -202,9 +198,7 @@ export async function pushTags(): Promise<IResponseString> {
   return promise;
 }
 
-export async function setGitTagVersion(
-  version: string,
-): Promise<IResponseString> {
+export async function setGitTagVersion(version: string): Promise<IResponseString> {
   const nextVersion = formatGitTagVersion(version);
   const cmd = `git tag -a ${nextVersion} -m ${nextVersion}`;
 
@@ -221,9 +215,7 @@ export async function setGitTagVersion(
   return promise;
 }
 
-export async function checkoutBranch(
-  branchName: string,
-): Promise<IResponseString> {
+export async function checkoutBranch(branchName: string): Promise<IResponseString> {
   const cmd = `git checkout ${branchName}`;
 
   const promise: Promise<IResponseString> = new Promise(res => {
@@ -263,6 +255,22 @@ export async function getRemote(): Promise<IResponseString> {
         res({ error: err.message });
       }
       res({ value });
+    });
+  });
+
+  return promise;
+}
+
+export async function getTags(): Promise<IResponseStringList> {
+  const cmd = `git tag`;
+
+  const promise: Promise<IResponseStringList> = new Promise(res => {
+    exec(cmd, (err, value) => {
+      if (err) {
+        res({ error: err.message });
+      }
+      const tags = value.split('\n').filter(Boolean);
+      res({ value: tags });
     });
   });
 


### PR DESCRIPTION
- Only pushing a specific git tag to remote to prevent the following error which subsequently used to exit the release process.
`error: failed to push some refs to remote. Updates were rejected because the tag already exists in 
the remote`

- Ran `npm audit fix`